### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ You can install slider field as a Wordpress plugin
 
 ```php
 array(
-	'name'    => 'Slider Field',
-	'desc'    => 'Set your value.',
-	'id'      => $prefix . 'slider',
-	'type'    => 'own_slider',
-	'min'     => '0',
-	'max'     => '200',
-	'default' => '0', // start value
+	'name'        => 'Slider Field',
+	'desc'        => 'Set your value.',
+	'id'          => $prefix . 'slider',
+	'type'        => 'own_slider',
+	'min'         => '0',
+	'max'         => '200',
+	'default'     => '0', // start value
+	'value_label' => 'Value:',
 ),
 ```
 ## Screenshots

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ You can install slider field as a Wordpress plugin
 
 ```php
 array(
-  'name' => 'Slider Field',
-  'desc' => 'Set your value.',
-  'id'   => $prefix . 'slider',
-  'type' => 'own_slider',
-  'min' => '0',
-  'max' => '200',
-  'start_value' => '0',
- ),
+	'name'    => 'Slider Field',
+	'desc'    => 'Set your value.',
+	'id'      => $prefix . 'slider',
+	'type'    => 'own_slider',
+	'min'     => '0',
+	'max'     => '200',
+	'default' => '0', // start value
+),
 ```
 ## Screenshots
 

--- a/cmb2_field_slider.php
+++ b/cmb2_field_slider.php
@@ -7,17 +7,21 @@
  * Author:      Mateusz Krupnik
  * License:     GPLv2+
  */
- 
+
 
 class OWN_Field_Slider {
 
+	const VERSION = '0.1.0';
+
 	public function hooks() {
 		add_filter( 'cmb2_render_own_slider',  array( $this, 'own_slider_field' ), 10, 5 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'setup_admin_scripts' ) );
 	}
 
 	public function own_slider_field( $field_args, $field_escaped_value, $field_object_id, $field_object_type, $field_type_object ) {
-	
+
+		// Only enqueue scripts if field is used.
+		$this->setup_admin_scripts();
+
 		$value = $field_args->escaped_value() ? $field_args->escaped_value() : $field_args->start_value();
 
 		echo '<input type="hidden" id="start" value="'.$value.'">';
@@ -25,21 +29,20 @@ class OWN_Field_Slider {
 		echo '<input type="hidden" id="max" value="'.$field_args->max().'">';
 
 		echo '<div id="slider"></div>';
-			
+
 		echo '<input type="hidden" id="amount" name="' . $field_args->id() . '" readonly />';
-			
-		echo '<p class="cmb2-metabox-description">'.$field_args->desc().'<span id="value"></span></p>';	 
+
+		echo '<p class="cmb2-metabox-description">'.$field_args->desc().'<span id="value"></span></p>';
 	}
 
-	 public function setup_admin_scripts( ) {
-	 
-	 	wp_enqueue_script( 'jquery-ui-slider');
-		wp_enqueue_script( 'cmb2_field_slider_js',  plugins_url( 'js/cmb2_field_slider.js', __FILE__ ), array( 'jquery' ), null );
-		
-		wp_enqueue_style( 'slider_ui', 'http://code.jquery.com/ui/1.11.3/themes/smoothness/jquery-ui.css', array(), '1.0', 'all' );
-		wp_enqueue_style( 'cmb2_field_slider_css', plugins_url( 'css/cmb2_field_slider.css', __FILE__ ), array(), '1.0', 'all' );
+	public function setup_admin_scripts( ) {
 
-	} 
+		wp_enqueue_script( 'cmb2_field_slider_js',  plugins_url( 'js/cmb2_field_slider.js', __FILE__ ), array( 'jquery', 'jquery-ui-slider' ), self::VERSION );
+
+		wp_register_style( 'slider_ui', 'http://code.jquery.com/ui/1.11.3/themes/smoothness/jquery-ui.css', array(), '1.0' );
+		wp_enqueue_style( 'cmb2_field_slider_css', plugins_url( 'css/cmb2_field_slider.css', __FILE__ ), array( 'slider_ui' ), self::VERSION );
+
+	}
 }
 $own_field_slider = new OWN_Field_Slider();
 $own_field_slider->hooks();

--- a/cmb2_field_slider.php
+++ b/cmb2_field_slider.php
@@ -17,22 +17,20 @@ class OWN_Field_Slider {
 		add_filter( 'cmb2_render_own_slider',  array( $this, 'own_slider_field' ), 10, 5 );
 	}
 
-	public function own_slider_field( $field_args, $field_escaped_value, $field_object_id, $field_object_type, $field_type_object ) {
+	public function own_slider_field( $field, $field_escaped_value, $field_object_id, $field_object_type, $field_type_object ) {
 
 		// Only enqueue scripts if field is used.
 		$this->setup_admin_scripts();
 
-		$value = $field_args->escaped_value() ? $field_args->escaped_value() : $field_args->start_value();
-
-		echo '<input type="hidden" id="start" value="'.$value.'">';
-		echo '<input type="hidden" id="min" value="'.$field_args->min().'">';
-		echo '<input type="hidden" id="max" value="'.$field_args->max().'">';
+		echo '<input type="hidden" id="start" value="'.absint( $field_escaped_value ).'">';
+		echo '<input type="hidden" id="min" value="'.$field->min().'">';
+		echo '<input type="hidden" id="max" value="'.$field->max().'">';
 
 		echo '<div id="slider"></div>';
 
-		echo '<input type="hidden" id="amount" name="' . $field_args->id() . '" readonly />';
+		echo '<input type="hidden" id="amount" name="' . $field->id() . '" readonly />';
 
-		echo '<p class="cmb2-metabox-description">'.$field_args->desc().'<span id="value"></span></p>';
+		echo '<p class="cmb2-metabox-description">'.$field->desc().'<span id="value"></span></p>';
 	}
 
 	public function setup_admin_scripts( ) {

--- a/cmb2_field_slider.php
+++ b/cmb2_field_slider.php
@@ -31,7 +31,7 @@ class OWN_Field_Slider {
 		echo '<input type="hidden" id="amount" name="' . $field->id() . '" readonly />';
 
 
-		echo '<span class="own-slider-field-value-display"></span>';
+		echo '<span class="own-slider-field-value-display">'. $field->value_label() .' <span class="own-slider-field-value-text"></span></span>';
 
 		$field_type_object->_desc( true, true );
 

--- a/cmb2_field_slider.php
+++ b/cmb2_field_slider.php
@@ -30,7 +30,11 @@ class OWN_Field_Slider {
 
 		echo '<input type="hidden" id="amount" name="' . $field->id() . '" readonly />';
 
-		echo '<p class="cmb2-metabox-description">'.$field->desc().'<span id="value"></span></p>';
+
+		echo '<span class="own-slider-field-value-display"></span>';
+
+		$field_type_object->_desc( true, true );
+
 	}
 
 	public function setup_admin_scripts( ) {

--- a/cmb2_field_slider.php
+++ b/cmb2_field_slider.php
@@ -22,19 +22,21 @@ class OWN_Field_Slider {
 		// Only enqueue scripts if field is used.
 		$this->setup_admin_scripts();
 
-		echo '<input type="hidden" id="start" value="'.absint( $field_escaped_value ).'">';
-		echo '<input type="hidden" id="min" value="'.$field->min().'">';
-		echo '<input type="hidden" id="max" value="'.$field->max().'">';
+		echo '<div class="own-slider-field"></div>';
 
-		echo '<div id="slider"></div>';
-
-		echo '<input type="hidden" id="amount" name="' . $field->id() . '" readonly />';
-
+		echo $field_type_object->input( array(
+			'type'       => 'hidden',
+			'class'      => 'own-slider-field-value',
+			'readonly'   => 'readonly',
+			'data-start' => absint( $field_escaped_value ),
+			'data-min'   => $field->min(),
+			'data-max'   => $field->max(),
+			'desc'       => '',
+		) );
 
 		echo '<span class="own-slider-field-value-display">'. $field->value_label() .' <span class="own-slider-field-value-text"></span></span>';
 
 		$field_type_object->_desc( true, true );
-
 	}
 
 	public function setup_admin_scripts( ) {

--- a/css/cmb2_field_slider.css
+++ b/css/cmb2_field_slider.css
@@ -4,7 +4,3 @@
 	font-size: 12px;
 	color: #888;
 }
-
-.own-slider-field-value-display:before {
-	content: "Value: ";
-}

--- a/css/cmb2_field_slider.css
+++ b/css/cmb2_field_slider.css
@@ -1,10 +1,10 @@
-#value{
+.own-slider-field-value-display {
 	float:right;
-	font: 400 12px Arial;
+	font-weight: 400;
+	font-size: 12px;
 	color: #888;
 }
-#value:before {
+
+.own-slider-field-value-display:before {
 	content: "Value: ";
 }
-
-

--- a/js/cmb2_field_slider.js
+++ b/js/cmb2_field_slider.js
@@ -1,7 +1,7 @@
 jQuery( document ).ready(function($) {
 
 	// Loop through all cmb-type-slider-field instances and instantiate the slider UI
-	$( '.cmb-type-slider-field' ).each(function() {
+	$( '.cmb-type-own-slider' ).each(function() {
 		var $this       = $( this );
 		var $value      = $this.find( '.own-slider-field-value' );
 		var $slider     = $this.find( '.own-slider-field' );

--- a/js/cmb2_field_slider.js
+++ b/js/cmb2_field_slider.js
@@ -1,17 +1,28 @@
 jQuery( document ).ready(function($) {
-   
-    $( "#slider" ).slider({
-      range: "min",
-	  value: $( "#start" ).val(),
-      min: $( "#min" ).val(),
-      max:  $( "#max" ).val(),
 
-      slide: function( event, ui ) {
-        $( "#amount" ).val( ui.value );
-		 $( "span#value" ).text( ui.value );
-      }
-    });
-    $( "#amount" ).val( $( "#slider" ).slider( "value" ) );
-	$( "span#value" ).text( $( "#slider" ).slider( "value" ) );
-	
+	// Loop through all cmb-type-slider-field instances and instantiate the slider UI
+	$( '.cmb-type-slider-field' ).each(function() {
+		var $this       = $( this );
+		var $value      = $this.find( '.own-slider-field-value' );
+		var $slider     = $this.find( '.own-slider-field' );
+		var $text       = $this.find( '.own-slider-field-value-text' );
+		var slider_data = $value.data();
+
+		$slider.slider({
+			range : 'min',
+			value : slider_data.start,
+			min   : slider_data.min,
+			max   : slider_data.max,
+			slide : function( event, ui ) {
+				$value.val( ui.value );
+				$text.text( ui.value );
+			}
+		});
+
+		// Initiate the display
+		$value.val( $slider.slider( 'value' ) );
+		$text.text( $slider.slider( 'value' ) );
+
+	});
+
 });


### PR DESCRIPTION
Hey, I know this is an unsolicited code review, but I like the idea of this field type very much. Unfortunately, the implementation had a few holes, so I refactored and here is a PR for you.
Some things that I addressed:
- CSS generated content (:before/:after fields) cannot be translated. I added an option field property to allow users to use their own string.
- The field was using ids, but a field type can be used more than once. This would break the field, (and ids should not be used more than once on a page). Also the ids were very generic and could overwrite existing WordPress ids. It's been updated to use classes.
- More than one usage of this field-type would cause it to break. It will now work with multiple uses.
- The plugin was loading the js/css on every wp-admin page (definitely overkill). Will now only enqueue those resources if the field is used.

For more details, see the commit messages.
